### PR TITLE
Dispatch a new event so the previous sales table can refresh.

### DIFF
--- a/app/Livewire/SaleForm.php
+++ b/app/Livewire/SaleForm.php
@@ -53,6 +53,8 @@ class SaleForm extends Component
                 'selling_price' => $sellingPrice,
             ]);
 
+            $this->dispatch('saleRecorded');
+
             $this->reset(['quantity', 'unitCost']);
             $this->sellingPrice = 0.00;
 

--- a/app/Livewire/SaleTable.php
+++ b/app/Livewire/SaleTable.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Models\Sale;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 class SaleTable extends Component
@@ -11,11 +12,20 @@ class SaleTable extends Component
 
     public function mount()
     {
-        $this->sales = Sale::all();
+        $this->loadSalesData();
+    }
+
+    #[On('saleRecorded')]
+    public function loadSalesData()
+    {
+        $this->sales = Sale::all()->sortByDesc('created_at');
     }
 
     public function render()
     {
-        return view('livewire.sale-table');
+        return view('livewire.sale-table', [
+                'sales' => $this->sales,
+            ]
+        );
     }
 }

--- a/resources/views/livewire/sale-form.blade.php
+++ b/resources/views/livewire/sale-form.blade.php
@@ -8,7 +8,7 @@
             </ul>
         </div>
     @endif
-    <form class="flex flex-row items-center space-x-4">
+    <div class="flex flex-row items-center space-x-4">
         <div>
             <label for="quantity" class="block">Quantity:</label>
             <input type="number" wire:model.live="quantity" id="quantity" name="quantity" class="border rounded-md px-2 py-1" min="1">
@@ -26,5 +26,5 @@
         <div>
             <button wire:click="recordSale" class="bg-green-500 text-white px-4 py-2 rounded-md font-bold">Record Sale</button>
         </div>
-    </form>
+    </div>
 </div>

--- a/tests/Feature/Livewire/SaleFormTest.php
+++ b/tests/Feature/Livewire/SaleFormTest.php
@@ -25,6 +25,16 @@ class SaleFormTest extends TestCase
     }
 
     /** @test */
+    public function creating_a_sale_dispatches_event()
+    {
+        Livewire::test(SaleForm::class)
+            ->set('quantity', 1)
+            ->set('unitCost', 10)
+            ->call('recordSale')
+            ->assertDispatched('saleRecorded');
+    }
+
+    /** @test */
     public function it_validates_required_fields()
     {
         Livewire::test(SaleForm::class)

--- a/tests/Feature/Livewire/SaleTableTest.php
+++ b/tests/Feature/Livewire/SaleTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Livewire;
 
 use App\Livewire\SaleTable;
 use App\Models\Sale;
@@ -42,5 +42,30 @@ class SaleTableTest extends TestCase
         // Mount the Livewire component without any sales data
         Livewire::test(SaleTable::class)
             ->assertSee('No sales recorded. Please enter using the form above to record a sale.');
+    }
+
+    /** @test */
+    public function sales_table_is_updated_when_event_is_dispatched()
+    {
+        Livewire::test(SaleTable::class)
+            ->call('loadSalesData')
+            ->assertSet('sales', Sale::all());
+
+        $this->assertCount(0, Sale::all());
+
+        // Add a new sale record
+        Sale::factory()->create([
+            'quantity' => 10,
+            'unit_cost' => 5,
+            'selling_price' => 10,
+        ]);
+
+        // Dispatch the saleRecorded event
+        Livewire::test(SaleTable::class)
+            ->call('loadSalesData')
+            ->dispatch('saleRecorded');
+
+        // Ensure the sales table is updated with new data
+        $this->assertCount(1, Sale::all());
     }
 }


### PR DESCRIPTION
Using Livewire's Events: https://livewire.laravel.com/docs/events 

We can get the Previous Sales table to listen each time this event is fired to grab a fresh data set on each new record. 